### PR TITLE
Nickname clipping fix

### DIFF
--- a/Ledybot/GTSBot7.cs
+++ b/Ledybot/GTSBot7.cs
@@ -409,7 +409,7 @@ namespace Ledybot
                                     Program.f1.giveawayDetails.TryGetValue(dexnumber, out details);
                                     if (details.Item1 == "")
                                     {
-                                        string szNickname = Encoding.Unicode.GetString(block, 0x14, 20).Trim('\0');
+                                        string szNickname = Encoding.Unicode.GetString(block, 0x14, 24).Trim('\0'); //fix to prevent nickname clipping. Count should be 24, 2 bytes per letter, 2x12=24, not 20.
                                         string szFileToFind = details.Item2 + szNickname + ".pk7";
                                         if (!File.Exists(szFileToFind))
                                         {
@@ -543,7 +543,7 @@ namespace Ledybot
                                     Program.f1.giveawayDetails.TryGetValue(dexnumber, out details);
                                     if (details.Item1 == "")
                                     {
-                                        string szNickname = Encoding.Unicode.GetString(block, 0x14, 20).Trim('\0');
+                                        string szNickname = Encoding.Unicode.GetString(block, 0x14, 24).Trim('\0'); //fix to prevent nickname clipping. Count should be 24, 2 bytes per letter, 2x12=24, not 20.
                                         string szFileToFind = details.Item2 + szNickname + ".pk7";
                                         if (!File.Exists(szFileToFind))
                                         {
@@ -666,7 +666,7 @@ namespace Ledybot
                         waitTaskbool = Program.helper.waitNTRwrite(addr_PageCurrentView, BitConverter.GetBytes(tradeIndex), iPID);
                         if (await waitTaskbool)
                         {
-                            string szNickname = Encoding.Unicode.GetString(block, 0x14, 20).Trim('\0');
+                            string szNickname = Encoding.Unicode.GetString(block, 0x14, 24).Trim('\0'); //fix to prevent nickname clipping. Count should be 24, 2 bytes per letter, 2x12=24, not 20.
 
 
                             string szPath = details.Item1;


### PR DESCRIPTION
20 bytes only includes 10 letters. Nickname has a max of 12 (24 bytes)